### PR TITLE
fix(npm): add utils folder to files array in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "email": "rdanielo@gmail.com",
     "url": "https://danielorodriguez.com"
   },
-  "files": ["generators"],
+  "files": ["generators", "utils"],
   "main": "generators/index.js",
   "keywords": ["hapi", "swagger", "docker", "ES6", "yeoman-generator"],
   "devDependencies": {


### PR DESCRIPTION
The folder **utils** is missing in **files** array of the package.json, so utils is not included when we install the generator as a dependency.